### PR TITLE
56 addpagination for large queries

### DIFF
--- a/app/models/pydantic/tools/pagination.py
+++ b/app/models/pydantic/tools/pagination.py
@@ -10,8 +10,8 @@ class PydanticPagination(BaseModel):
     """
     Model that helps with pagination.
     """
-    page: int = 1
-    limit: int = 50
+    page    : int = 1
+    limit   : int = 50
     order_by: str = "id"
 
     def compute_offset(self) -> int:

--- a/app/models/pydantic/tools/pagination.py
+++ b/app/models/pydantic/tools/pagination.py
@@ -1,0 +1,29 @@
+"""
+Module that provides Pagination for large queries.
+"""
+from pydantic import BaseModel
+from tortoise import Model
+from tortoise.queryset import QuerySet
+
+
+class PydanticPagination(BaseModel):
+    """
+    Model that helps with pagination.
+    """
+    page: int = 1
+    limit: int = 50
+    order_by: str = "id"
+
+    def compute_offset(self) -> int:
+        """
+        This method computes the offset for the query.
+        """
+        return (self.page - 1) * self.limit
+
+    async def paginate_query(self, query: QuerySet[Model]) -> list[Model]:
+        """
+        This method fetches the data from the query provided with pagination.
+        """
+        return await query.offset(self.compute_offset())\
+                          .limit(self.limit)\
+                          .order_by(self.order_by)


### PR DESCRIPTION
Added pagination Pydantic model.
Can be used in request bodies to indicate the size of the page and the number of the page.
Can also be used to sort the elements of the query. However, it requires to know what is the column name you want to sort.
All these values have a default setting if nothing is given in the request. 