### PR TITLE
Fixed the issue.

### DIFF
--- a/app/models/pydantic/UEModel.py
+++ b/app/models/pydantic/UEModel.py
@@ -13,7 +13,7 @@ class PydanticUEModelFromJSON(BaseModel):
     Pydantic model for loading data from a JSON file.
     """
     name           : str
-    courses_id_m2m : list[int]
+    courses_m2m : list[int]
     academic_year  : int
     parent_id      : int | None
 

--- a/app/models/tortoise/ue.py
+++ b/app/models/tortoise/ue.py
@@ -1,7 +1,8 @@
 """
 This module contains the model for the UE.
 """
-from tortoise.fields import ManyToManyField, ManyToManyRelation, ForeignKeyNullableRelation, ForeignKeyField
+from tortoise.fields import (ManyToManyField, ManyToManyRelation,
+                             ForeignKeyNullableRelation, ForeignKeyField)
 
 from app.models.tortoise.course import CourseInDB
 from app.models.tortoise.node import NodeInDB
@@ -19,7 +20,7 @@ class UEInDB(NodeInDB):
 
     courses : ManyToManyRelation[CourseInDB] = ManyToManyField("models.CourseInDB",
                                                                related_name="ue",
-                                                               through="ue_courses")
+                                                               through="UE_COURSES_ASSOCIATION")
 
     class Meta(NodeInDB.Meta):
         """

--- a/app/static/templates/json/ue_templates.json
+++ b/app/static/templates/json/ue_templates.json
@@ -1,43 +1,43 @@
 [
     {
         "name": "UE 1",
-        "courses_id_m2m": [1, 2, 3, 4, 5],
+        "courses_m2m": [1, 2, 3, 4, 5],
         "academic_year": 2024,
         "parent_id": 5
     },
     {
         "name": "UE 2",
-        "courses_id_m2m": [6, 7, 8, 9, 10],
+        "courses_m2m": [6, 7, 8, 9, 10],
         "academic_year": 2025,
         "parent_id": 5
     },
     {
         "name": "UE 3",
-        "courses_id_m2m": [11, 12, 13, 14, 15],
+        "courses_m2m": [11, 12, 13, 14, 15],
         "academic_year": 2024,
         "parent_id": 6
     },
     {
         "name": "UE 4",
-        "courses_id_m2m": [16, 17, 18, 19, 20],
+        "courses_m2m": [16, 17, 18, 19, 20],
         "academic_year": 2025,
         "parent_id": 7
     },
     {
         "name": "UE 5",
-        "courses_id_m2m": [21, 22, 23, 24, 25],
+        "courses_m2m": [21, 22, 23, 24, 25],
         "academic_year": 2024,
         "parent_id": 7
     },
     {
         "name": "UE 6",
-        "courses_id_m2m": [26, 27, 28, 29, 30],
+        "courses_m2m": [26, 27, 28, 29, 30],
         "academic_year": 2025,
         "parent_id": 7
     },
     {
         "name": "UE 7",
-        "courses_id_m2m": [31],
+        "courses_m2m": [31],
         "academic_year": 2024,
         "parent_id": 8
     }


### PR DESCRIPTION
I'm now pretty sure that the management of foreign keys has changed in Tortoise.
Removed the _id suffix in the M2M data that links courses and UEs.
Closes #77